### PR TITLE
fix: jq vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM vault:1.9.2
 ARG KUBECTL_VERSION="stable"
 
 # Add more dependencies
-RUN apk add  --no-cache jq bash curl openssl \
-    && [ "${KUBECTL_VERSION}" = "stable" ] && KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) \
-    && curl -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
-    && chmod +x ./kubectl \
-    && mv ./kubectl /usr/local/bin/kubectl
+RUN apk add  --no-cache bash \
+    && [ "${KUBECTL_VERSION}" = "stable" ] && KUBECTL_VERSION=$(wget -O - https://storage.googleapis.com/kubernetes-release/release/stable.txt) \
+    && cd /usr/local/bin \
+    && wget "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+    && chmod +x /usr/local/bin/kubectl
 
 USER vault
 CMD bash


### PR DESCRIPTION
We are not using jq anymore, remove it.
Also remove curl and openssl, just need wget (which is included)