### PR TITLE
fix: remove default service account name

### DIFF
--- a/charts/vault-gcp-secrets/Chart.yaml
+++ b/charts/vault-gcp-secrets/Chart.yaml
@@ -5,5 +5,5 @@ home: https://github.com/TJM/vault-gcp-secrets
 # icon: https://raw.githubusercontent.com/TJM/vault-gcp-secrets/master/assets/logo.png
 maintainers:
   - name: TJM  # Tommy McNeely
-version: 0.8.1
+version: 0.8.2
 appVersion: 1.10.0  # REMINDER: update README and values.yaml

--- a/charts/vault-gcp-secrets/values.yaml
+++ b/charts/vault-gcp-secrets/values.yaml
@@ -77,7 +77,7 @@ rbac:
 
 serviceAccount:
   create: true
-  name: vault-gcp-secrets
+  name: ~
 
 # Annotations for vault-gcp-secrets pod(s).
 podAnnotations: {}


### PR DESCRIPTION
This fixes an issue where multiple installations trying to create a svc account will clash.