### PR TITLE
fix: remove extra new line in key.json

### DIFF
--- a/charts/vault-gcp-secrets/Chart.yaml
+++ b/charts/vault-gcp-secrets/Chart.yaml
@@ -5,5 +5,5 @@ home: https://github.com/TJM/vault-gcp-secrets
 # icon: https://raw.githubusercontent.com/TJM/vault-gcp-secrets/master/assets/logo.png
 maintainers:
   - name: TJM
-version: 1.8.1
+version: 1.8.2
 appVersion: "v1.12.2"

--- a/charts/vault-gcp-secrets/templates/configmap.yaml
+++ b/charts/vault-gcp-secrets/templates/configmap.yaml
@@ -64,9 +64,9 @@ data:
     }
 
   template.ctmpl: |
-    {{ "{{" }} with secret "{{ .Values.vault.gcpSecretPath }}" {{ "}}" }}
+    {{ "{{-" }} with secret "{{ .Values.vault.gcpSecretPath }}" {{ "-}}" }}
     {{ "{{" }} {{ .Values.secret.template }} {{ "}}" }}
-    {{ "{{" }} end {{ "}}" }}
+    {{ "{{" }} end {{ "-}}" }}
 
   template-command.sh: |
     #!/bin/bash


### PR DESCRIPTION
Remove extraneous newlines, but keep the one at the end of the file.